### PR TITLE
Update gift message and new guard message

### DIFF
--- a/graphql/vNerve.gql
+++ b/graphql/vNerve.gql
@@ -1,0 +1,134 @@
+type Query{
+	linkSyntaxs: [LinkSyntax!]
+	vdb: VDB
+	bilibiliInfoEntrys: [BiliBiliInfo!]
+}
+
+type LinkSyntax{
+	platform: String
+	url: String
+}
+
+type VDB{
+	vtubers: [VTuber!]
+	groups: [Group!]
+	fans: [Fan!]
+}
+
+interface VdbEntry{
+	uuid: ID
+	accounts: [Account!]
+	name: String
+	nameExtra: String
+	nameTranslations: [NameTranslation!]
+}
+
+type VTuber implements VdbEntry{
+	uuid: ID
+	bot: Boolean
+	accounts: [Account!]
+	name: String
+	nameExtra: String
+	nameTranslations: [NameTranslation!]
+	group: Group
+	model2d: Boolean
+	model3d: Boolean
+}
+
+type Group implements VdbEntry{
+	uuid: ID
+	accounts: [Account!]
+	name: String
+	nameExtra: String
+	nameTranslations: [NameTranslation!]
+}
+
+type Fan implements VdbEntry{
+	uuid: ID
+	accounts: [Account!]
+	name: String
+	nameExtra: String
+	nameTranslations: [NameTranslation!]
+}
+
+type Account{
+	id: ID
+	accountType: AccountType
+	accountPlatform: AccountPlatform
+}
+
+type NameTranslation{
+	language: String!
+	translation: String!
+}
+
+enum AccountType{
+	UNKNOWN_ACCOUNT_TYPE
+	OFFICIAL
+	RELAY
+}
+
+enum AccountPlatform{
+	UNKNOWN_PLATFORM
+	BILIBILI
+	TWITTER
+	YOUTUBE
+	USERLOCAL
+	PEING
+	MARSHMALLOW
+	PIXIV
+	WEIBO
+	BOOTH
+	AFDIAN
+	WEB
+	EMAIL
+	INSTAGRAM
+	POPIASK
+	AMAZON_CO_JP
+	TWITCH
+	NICONICO
+	FACEBOOK
+	TEESPRING
+	PATREON
+	JVCMUSIC
+	CI_EN
+	GITHUB
+	LINE
+	TIKTOK
+	FANTIA
+	SHOWROOM
+	TELEGRAM
+}
+
+type BiliBiliInfo{
+	uuid: String
+	uid: Int
+	userName: String
+	roomId: Int
+	follow: Int
+	followDailyIncrement: Int
+	roomTitle: String
+	liveStatus: LiveStatus
+	popularity: Int
+	rankArea: Int
+	description: String
+	roomNotice: String
+	avatarUrl: String
+	bannerImageUrl: String
+	videoCount: Int
+	videoTotalViews: Int
+	guardCount: Int
+	guardLevel1: Int
+	guardLevel2: Int
+	guardLevel3: Int
+}
+
+enum LiveStatus{
+	PREPARING
+	LIVE
+	ROUND
+	CUT_OFF
+}
+schema{
+	query: Query
+}

--- a/graphql/vNerve.gql
+++ b/graphql/vNerve.gql
@@ -1,60 +1,66 @@
 type Query{
-	linkSyntaxs: [LinkSyntax!]
-	vdb: VDB
-	bilibiliInfoEntrys: [BiliBiliInfo!]
+	linkSyntaxs: [LinkSyntax!]!
+	vdb: VDB!
+	allBiliBiliInfo: [BiliBiliInfo!]!
+	bilibiliInfoByUids(
+		uids: [ID!]!
+	): [BiliBiliInfo!]!
+	bilibiliInfoByUserNames(
+		userNames: [String!]!
+	): [BiliBiliInfo!]!
 }
 
 type LinkSyntax{
-	platform: String
-	url: String
+	platform: String!
+	url: String!
 }
 
 type VDB{
-	vtubers: [VTuber!]
-	groups: [Group!]
-	fans: [Fan!]
+	vtubers: [VTuber!]!
+	groups: [Group!]!
+	fans: [Fan!]!
 }
 
 interface VdbEntry{
-	uuid: ID
-	accounts: [Account!]
-	name: String
+	uuid: ID!
+	accounts: [Account!]!
+	name: String!
 	nameExtra: String
-	nameTranslations: [NameTranslation!]
+	nameTranslations: [NameTranslation!]!
 }
 
 type VTuber implements VdbEntry{
-	uuid: ID
+	uuid: ID!
 	bot: Boolean
-	accounts: [Account!]
-	name: String
+	accounts: [Account!]!
+	name: String!
 	nameExtra: String
-	nameTranslations: [NameTranslation!]
+	nameTranslations: [NameTranslation!]!
 	group: Group
 	model2d: Boolean
 	model3d: Boolean
 }
 
 type Group implements VdbEntry{
-	uuid: ID
-	accounts: [Account!]
-	name: String
+	uuid: ID!
+	accounts: [Account!]!
+	name: String!
 	nameExtra: String
-	nameTranslations: [NameTranslation!]
+	nameTranslations: [NameTranslation!]!
 }
 
 type Fan implements VdbEntry{
-	uuid: ID
-	accounts: [Account!]
-	name: String
+	uuid: ID!
+	accounts: [Account!]!
+	name: String!
 	nameExtra: String
-	nameTranslations: [NameTranslation!]
+	nameTranslations: [NameTranslation!]!
 }
 
 type Account{
-	id: ID
-	accountType: AccountType
-	accountPlatform: AccountPlatform
+	id: ID!
+	accountType: AccountType!
+	accountPlatform: AccountPlatform!
 }
 
 type NameTranslation{
@@ -101,26 +107,30 @@ enum AccountPlatform{
 }
 
 type BiliBiliInfo{
-	uuid: String
-	uid: Int
-	userName: String
-	roomId: Int
-	follow: Int
-	followDailyIncrement: Int
-	roomTitle: String
-	liveStatus: LiveStatus
-	popularity: Int
-	rankArea: Int
-	description: String
-	roomNotice: String
-	avatarUrl: String
-	bannerImageUrl: String
-	videoCount: Int
-	videoTotalViews: Int
-	guardCount: Int
-	guardLevel1: Int
-	guardLevel2: Int
-	guardLevel3: Int
+	uuid: String!
+	uid: Int!
+	userName: String!
+	roomId: Int!
+	follow: Int!
+	followDailyIncrement: Int!
+	description: String!
+	avatarUrl: String!
+	bannerImageUrl: String!
+	videoCount: Int!
+	videoTotalViews: Int!
+	bilibiliLiveInfo: BilibiliLiveInfo
+}
+
+type BilibiliLiveInfo{
+	roomTitle: String!
+	liveStatus: LiveStatus!
+	popularity: Int!
+	rankArea: Int!
+	roomNotice: String!
+	guardCount: Int!
+	guardLevel1: Int!
+	guardLevel2: Int!
+	guardLevel3: Int!
 }
 
 enum LiveStatus{

--- a/vNerve/bilibili/live/user_message.proto
+++ b/vNerve/bilibili/live/user_message.proto
@@ -82,7 +82,8 @@ message GiftMessage {
 
   uint32 gift_id = 3;
   string gift_name = 4;
-  uint32 gift_single_coin = 5;
+  uint32 price = 5;
+  uint32 num=6;
 }
 
 message WelcomeVIPMessage {
@@ -101,9 +102,24 @@ enum GuardLevel {
   LEVEL3 = 3;
 }
 
+enum GuardBuyType {
+  None=0;
+  Buy=1;
+  Renew=2;
+}
+
+enum GuardUnit {
+  None=0;
+  Month=1;
+  Week=2;
+}
+
 message NewGuardMessage {
   GuardLevel level = 1;
-  uint32 coin = 2;
+  uint32 total_coin = 2;
+  uint32 num=3;
+  GuardUnit unit=4;
+  GuardBuyType buy_type=5;
 }
 
 message UserBlockedMessage {


### PR DESCRIPTION
修改了一下 GiftMessage和NewGuardMessage

GiftMessage加上了数量（num）把gift_single_coin改为price，因为total_coin存在打折的情况，并不能准确计算出礼物的数量

NewGuardMessage补充了更多信息，包括数量、购买类型（开通、续费），周期（目前有周舰长和月舰长）

数据来源为USER_TOAST_MSG，该数据样例：
{
    "cmd": "USER_TOAST_MSG",
    "data": {
        "num": 2,
        "uid": 23523656,
        "unit": "月",
        "price": 316000,\\总价
        "is_show": 0,
        "op_type": 2,\\1为开通，2为续费
        "end_time": 1588305442,
        "username": "迷咕咕",
        "role_name": "舰长",
        "toast_msg": "<%迷咕咕%>续费了主播的舰长",
        "user_show": true,
        "start_time": 1588305442,
        "anchor_show": true,
        "guard_level": 3
    }
}