### PR TITLE
(bili.live): Optimized GiftMessage and NewGuardMessage

### DIFF
--- a/vNerve/bilibili/live/user_message.proto
+++ b/vNerve/bilibili/live/user_message.proto
@@ -82,7 +82,7 @@ message GiftMessage {
 
   uint32 gift_id = 3;
   string gift_name = 4;
-  uint32 price_coin  = 5;
+  uint32 price_coin = 5;
   uint32 num = 6;
 }
 
@@ -104,8 +104,8 @@ enum GuardLevel {
 
 enum GuardBuyType {
   None = 0;
-  Buy= 1;
-  Renew= 2;
+  Buy = 1;
+  Renew = 2;
 }
 
 enum GuardDuration {

--- a/vNerve/bilibili/live/user_message.proto
+++ b/vNerve/bilibili/live/user_message.proto
@@ -82,7 +82,8 @@ message GiftMessage {
 
   uint32 gift_id = 3;
   string gift_name = 4;
-  uint32 gift_single_coin = 5;
+  uint32 price = 5;
+  uint32 num=6;
 }
 
 message WelcomeVIPMessage {
@@ -101,9 +102,24 @@ enum GuardLevel {
   LEVEL3 = 3;
 }
 
+enum GuardBuyType {
+  None=0;
+  Buy=1;
+  Renew=2;
+}
+
+enum GuardUnit {
+  None=0;
+  Month=1;
+  Week=2;
+}
+
 message NewGuardMessage {
   GuardLevel level = 1;
-  uint32 coin = 2;
+  uint32 total_coin = 2;
+  uint32 num = 3;
+  GuardUnit unit = 4;
+  GuardBuyType buy_type=5;
 }
 
 message UserBlockedMessage {

--- a/vNerve/bilibili/live/user_message.proto
+++ b/vNerve/bilibili/live/user_message.proto
@@ -108,7 +108,7 @@ enum GuardBuyType {
   Renew= 2;
 }
 
-enum GuardUnit {
+enum GuardDuration {
   None = 0;
   Month = 1;
   Week = 2;
@@ -118,7 +118,7 @@ message NewGuardMessage {
   GuardLevel level = 1;
   uint32 total_coin = 2;
   uint32 num = 3;
-  GuardUnit unit = 4;
+  GuardDuration duration = 4;
   GuardBuyType buy_type = 5;
 }
 

--- a/vNerve/bilibili/live/user_message.proto
+++ b/vNerve/bilibili/live/user_message.proto
@@ -82,8 +82,8 @@ message GiftMessage {
 
   uint32 gift_id = 3;
   string gift_name = 4;
-  uint32 price = 5;
-  uint32 num=6;
+  uint32 price_coin  = 5;
+  uint32 num = 6;
 }
 
 message WelcomeVIPMessage {
@@ -103,15 +103,15 @@ enum GuardLevel {
 }
 
 enum GuardBuyType {
-  None=0;
-  Buy=1;
-  Renew=2;
+  None = 0;
+  Buy= 1;
+  Renew= 2;
 }
 
 enum GuardUnit {
-  None=0;
-  Month=1;
-  Week=2;
+  None = 0;
+  Month = 1;
+  Week = 2;
 }
 
 message NewGuardMessage {
@@ -119,7 +119,7 @@ message NewGuardMessage {
   uint32 total_coin = 2;
   uint32 num = 3;
   GuardUnit unit = 4;
-  GuardBuyType buy_type=5;
+  GuardBuyType buy_type = 5;
 }
 
 message UserBlockedMessage {


### PR DESCRIPTION
修改了一下 GiftMessage和NewGuardMessage

GiftMessage加上了数量（num）把gift_single_coin改为price，因为total_coin存在打折的情况，并不能准确计算出礼物的数量

NewGuardMessage补充了更多信息，包括数量、购买类型（开通、续费），周期（目前有周舰长和月舰长）

数据来源为USER_TOAST_MSG，该数据样例：
```json
{
"cmd": "USER_TOAST_MSG",
"data": {
"num": 2,
"uid": 23523656,
"unit": "月",
"price": 316000,//总价
"is_show": 0,
"op_type": 2,//1为开通，2为续费
"end_time": 1588305442,
"username": "迷咕咕",
"role_name": "舰长",
"toast_msg": "<%迷咕咕%>续费了主播的舰长",
"user_show": true,
"start_time": 1588305442,
"anchor_show": true,
"guard_level": 3
}
}
```